### PR TITLE
2 add ou value to group member relationship field field course ou

### DIFF
--- a/src/GroupLMSUserSyncAPI.php
+++ b/src/GroupLMSUserSyncAPI.php
@@ -152,6 +152,22 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                       }
 
                       $group->addMember($user_obj);
+                      /* TODO: Issue # 2 */
+                      /* Call method $group->getMember(), it will return a Group Membership entity object */
+                      /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
+                      //$group_type = $this->createGroupType();
+                      //$group = $this->createGroup(['type' => $group_type->id()]);
+                  
+                      //$account = $this->createUser();
+                      //$group->addMember($account);
+                      //group_relationship = $group->getMember($account)->getGroupRelationship();
+                  
+                      // Canonical.
+                      //$expected = "/group/{$group->id()}/content/{$group_relationship->id()}";
+                      //$this->assertEquals($expected, $group_relationship->toUrl()->toString());
+                      $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+                      $group_relationship->field_course_ou->value = $group_id_api;
+
                       $count_updated_groups[$user_id_api] = $group->id();
                       $group_name = $group->label();
                       $this->logger->notice("Added user @username to group @groupname", ['@username' => $username_api, '@groupname' => $group_id_api]);
@@ -179,6 +195,12 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                         }
 
                         $group->addMember($user_new);
+                        /* TODO: Issue # 2 */
+                        /* Call method $group->getMember(), it will return a Group Membership entity object */
+                        /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
+                        $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+                        $group_relationship->field_course_ou->value = $group_id_api;
+
                         $count_updated_groups[$user_id_api] = $group->id();
                         $group_name = $group->label();
                         $this->logger->notice("Added user @username to group @groupname", ['@username' => $username_api, '@groupname' => $group_id_api]);
@@ -259,8 +281,15 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
             }
 
             $group->addMember($user_obj);
+            /* TODO: Issue # 2 */
+            /* Call method $group->getMember(), it will return a Group Membership entity object */
+            /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
+            $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+            $group_relationship->field_course_ou->value = $group_id_api;
+
             $count_updated_groups[$user_id_api] = $group->id();
             $group_name = $group->label();
+
             $this->messenger->addStatus(t("Added user @username to group @groupname", ['@username' => $username_api, '@groupname' => $group_id_api]));
             $this->logger->notice("Added user @username to group @groupname", ['@username' => $username_api, '@groupname' => $group_id_api]);
           }
@@ -289,6 +318,12 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
               }
 
               $group->addMember($user_new);
+              /* TODO: Issue # 2 */
+              /* Call method $group->getMember(), it will return a Group Membership entity object */
+              /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
+              $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+              $group_relationship->field_course_ou->value = $group_id_api;
+              
               $count_updated_groups[$user_id_api] = $group->id();
               $group_name = $group->label();
 

--- a/src/GroupLMSUserSyncAPI.php
+++ b/src/GroupLMSUserSyncAPI.php
@@ -155,7 +155,6 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                       $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
                       $group_relationship->field_course_ou->value = $group_id_api;
                       $group_relationship->save();
-                      $group->save();
 
                       $count_updated_groups[$user_id_api] = $group->id();
                       $group_name = $group->label();
@@ -187,7 +186,6 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                         $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
                         $group_relationship->field_course_ou->value = $group_id_api;
                         $group_relationship->save();
-                        $group->save();
 
                         $count_updated_groups[$user_id_api] = $group->id();
                         $group_name = $group->label();
@@ -272,7 +270,6 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
             $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
             $group_relationship->field_course_ou->value = $group_id_api;
             $group_relationship->save();
-            $group->save();
 
             $count_updated_groups[$user_id_api] = $group->id();
             $group_name = $group->label();
@@ -308,7 +305,6 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
               $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
               $group_relationship->field_course_ou->value = $group_id_api;
               $group_relationship->save();
-              $group->save();
 
               $count_updated_groups[$user_id_api] = $group->id();
               $group_name = $group->label();

--- a/src/GroupLMSUserSyncAPI.php
+++ b/src/GroupLMSUserSyncAPI.php
@@ -166,7 +166,10 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                       //$expected = "/group/{$group->id()}/content/{$group_relationship->id()}";
                       //$this->assertEquals($expected, $group_relationship->toUrl()->toString());
                       $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+                      $group_member = $group->getMember($user_obj);
                       $group_relationship->field_course_ou->value = $group_id_api;
+                      $group_relationship->save();
+                      $group->save();
 
                       $count_updated_groups[$user_id_api] = $group->id();
                       $group_name = $group->label();
@@ -199,7 +202,10 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                         /* Call method $group->getMember(), it will return a Group Membership entity object */
                         /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
                         $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+                        $group_member = $group->getMember($user_obj);
                         $group_relationship->field_course_ou->value = $group_id_api;
+                        $group_relationship->save();
+                        $group->save();
 
                         $count_updated_groups[$user_id_api] = $group->id();
                         $group_name = $group->label();
@@ -285,7 +291,10 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
             /* Call method $group->getMember(), it will return a Group Membership entity object */
             /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
             $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+            $group_member = $group->getMember($user_obj);
             $group_relationship->field_course_ou->value = $group_id_api;
+            $group_relationship->save();
+            $group->save();
 
             $count_updated_groups[$user_id_api] = $group->id();
             $group_name = $group->label();
@@ -322,8 +331,11 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
               /* Call method $group->getMember(), it will return a Group Membership entity object */
               /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
               $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
+              $group_member = $group->getMember($user_obj);
               $group_relationship->field_course_ou->value = $group_id_api;
-              
+              $group_relationship->save();
+              $group->save();
+
               $count_updated_groups[$user_id_api] = $group->id();
               $group_name = $group->label();
 

--- a/src/GroupLMSUserSyncAPI.php
+++ b/src/GroupLMSUserSyncAPI.php
@@ -152,21 +152,7 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                       }
 
                       $group->addMember($user_obj);
-                      /* TODO: Issue # 2 */
-                      /* Call method $group->getMember(), it will return a Group Membership entity object */
-                      /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
-                      //$group_type = $this->createGroupType();
-                      //$group = $this->createGroup(['type' => $group_type->id()]);
-                  
-                      //$account = $this->createUser();
-                      //$group->addMember($account);
-                      //group_relationship = $group->getMember($account)->getGroupRelationship();
-                  
-                      // Canonical.
-                      //$expected = "/group/{$group->id()}/content/{$group_relationship->id()}";
-                      //$this->assertEquals($expected, $group_relationship->toUrl()->toString());
                       $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
-                      $group_member = $group->getMember($user_obj);
                       $group_relationship->field_course_ou->value = $group_id_api;
                       $group_relationship->save();
                       $group->save();
@@ -198,11 +184,7 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
                         }
 
                         $group->addMember($user_new);
-                        /* TODO: Issue # 2 */
-                        /* Call method $group->getMember(), it will return a Group Membership entity object */
-                        /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
                         $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
-                        $group_member = $group->getMember($user_obj);
                         $group_relationship->field_course_ou->value = $group_id_api;
                         $group_relationship->save();
                         $group->save();
@@ -287,11 +269,7 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
             }
 
             $group->addMember($user_obj);
-            /* TODO: Issue # 2 */
-            /* Call method $group->getMember(), it will return a Group Membership entity object */
-            /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
             $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
-            $group_member = $group->getMember($user_obj);
             $group_relationship->field_course_ou->value = $group_id_api;
             $group_relationship->save();
             $group->save();
@@ -327,11 +305,7 @@ class GroupLMSUserSyncAPI implements ContainerInjectionInterface {
               }
 
               $group->addMember($user_new);
-              /* TODO: Issue # 2 */
-              /* Call method $group->getMember(), it will return a Group Membership entity object */
-              /* We will use this object to set the custom field field_course_ou and save the Group Membership Entity */
               $group_relationship = $group->getMember($user_obj)->getGroupRelationship();
-              $group_member = $group->getMember($user_obj);
               $group_relationship->field_course_ou->value = $group_id_api;
               $group_relationship->save();
               $group->save();


### PR DESCRIPTION
- Added instructions to get the $group_relationship object from the $group object and set the course OU field
- The OU field will be updated if, for some reason, the data is deleted in the group membership
- TODO: A hook (?) that removes the user from the Group if the OU field in the group membership is deleted or updated to another Group API ID.